### PR TITLE
use setuptools and not distutils for more convenient development

### DIFF
--- a/EoN/simulation_investigation.py
+++ b/EoN/simulation_investigation.py
@@ -275,6 +275,12 @@ class Simulation_Investigation():
             node_times = self._node_history_[node][0]
             node_statuses = self._node_history_[node][1]
             tmin = node_times[0] #should be the same for each node, but hard to choose a single node at start.
+            ## this can happen with contagions on a bipartite
+            ## graph where a subset of nodes do not have an
+            ## infection status
+            if node_statuses[0] not in delta:
+                continue
+
             times.add(tmin)
             delta[node_statuses[0]][tmin]+=1
             for new_status, old_status, time in zip(node_statuses[1:], node_statuses[:-1], node_times[1:]):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ If this is a "release candidate" (has an "rc" in the version name below), then
 pip will download the previous version - see the download_url below.
 '''
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='EoN',
       packages = ['EoN'], 


### PR DESCRIPTION
Using setuptools instead of distutils makes it possible to do `python setup.py develop` which will use the in-place checked out version of the source. This makes it a lot easier to work with packages that depend on EoN and imply changes in EoN (of which more to follow).